### PR TITLE
 CRITICAL FIX: Update Pipeline Logic to Use Inforce Date

### DIFF
--- a/AGENT_TUTORIAL.md
+++ b/AGENT_TUTORIAL.md
@@ -35,8 +35,8 @@
 ### Critical Dates
 - **Policy Entry Date**: When you created this policy in the system
 - **First Payment Date**: When client's first premium payment is due
-- **Inforce Date**: When policy coverage officially begins
-- **🎯 Date Verified**: When YOU confirmed commission was actually paid
+- **🎯 Inforce Date**: When policy coverage officially begins (3 business days after first payment when bank confirms funds transfer) - **THIS determines which payment period your commission appears in**
+- **Date Verified**: When YOU confirmed commission was actually paid
 
 ### Commission Tracking
 - **Commission Due**: Calculated commission amount (Premium × Rate)
@@ -189,8 +189,14 @@ Instead of scattered alerts, the system sends **professional, grouped messages**
 The Pipeline tab shows **future commission payments** by period:
 - **Next 6 Payment Periods**: Upcoming commission opportunities
 - **Expected Amount**: Based on unverified policies
-- **Policy Count**: Number of policies in each period
+- **Policy Count**: Number of policies in each period (based on **inforce date**)
 - **Days Until Payment**: Countdown to payment date
+
+#### 🎯 **Important: Pipeline Mapping Logic**
+**Policies appear in payment periods based on their INFORCE DATE, not policy creation date!**
+- **Inforce Date**: When bank confirms funds transferred (typically 3 business days after first payment)
+- **Fallback**: If no inforce date set, uses policy creation date
+- **Why**: Commission becomes due when policy is officially in-force, not when you first entered it
 
 ### Pipeline Strategy
 1. **Review Regularly**: Check pipeline weekly

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A comprehensive commission management system for life insurance agents featuring
 - **Policy-Level Verification**: Track individual policy commission status
 - **Cross-Reference Tools**: Match internal records with external spreadsheets
 - **Smart Defaulting**: Auto-populate based on existing verification status
+- **🎯 Inforce Date Logic**: Policies mapped to payment periods based on inforce date (when commission becomes due), not creation date
 
 ### 📱 **NEW: Professional Slack Integration**
 - **Consolidated Notifications**: Grouped alerts instead of spam

--- a/src/components/PolicyTable.tsx
+++ b/src/components/PolicyTable.tsx
@@ -1107,7 +1107,7 @@ const PolicyTable = forwardRef<PolicyTableRef, PolicyTableProps>(({ onPolicyUpda
                     </td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm">
                       {(() => {
-                        const paymentInfo = getPaymentPeriodForPolicy(policy.created_at);
+                        const paymentInfo = getPaymentPeriodForPolicy(policy.inforce_date, policy.created_at);
                         if (!policy.date_policy_verified && paymentInfo.paymentDate) {
                           return (
                             <div>


### PR DESCRIPTION
 **Business Logic Correction:**
- Updated calculateExpectedCommissionForPeriod() to use inforce_date instead of created_at
- Updated getPaymentPeriodForPolicy() to prioritize inforce_date with fallback to created_at
- Fixed PolicyTable.tsx call to use inforce_date for payment period mapping

 **Why This Matters:**
- Inforce date = when bank confirms funds transferred (3 business days after first payment)
- Commission becomes DUE when policy is in-force, not when initially created
- Aligns with commission team's actual payment trigger logic
- Ensures policies appear in correct payment periods

 **Documentation Updates:**
- Updated AGENT_TUTORIAL.md to highlight inforce date importance
- Added business logic explanation to README.md
- Clarified that inforce date determines payment period mapping

 **Backward Compatibility:**
- Falls back to created_at when inforce_date is null
- No data loss for existing policies without inforce dates
- Seamless transition for ongoing operations

This is the accurate business logic that reflects how commissions actually work!